### PR TITLE
Refactor ranktable method

### DIFF
--- a/cogs/gatekeeper.py
+++ b/cogs/gatekeeper.py
@@ -371,13 +371,16 @@ class LevelUp(commands.Cog):
     @discord.app_commands.guild_only()
     async def ranktable(self, interaction: discord.Interaction):
         quiz_roles = await self.get_all_quiz_roles(interaction.guild)
-        description = "\n".join([f"{role.mention}: {len(role.members)} ({len(
-            role.members) / interaction.guild.member_count * 100:.2f}%)" for role in quiz_roles])
+        description = "\n".join([
+            f"{role.mention}: {len(role.members)} ({len(role.members) / interaction.guild.member_count * 100:.2f}%)"
+            for role in quiz_roles
+        ])
 
         description += f"\n\nTotal member count: {interaction.guild.member_count}"
 
         embed = discord.Embed(title=f"Role Distribution", description=description, color=discord.Color.blurple())
         await interaction.response.send_message(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+
 
     @discord.app_commands.command(name="rankusers", description="See all users with a specific role.")
     @discord.app_commands.describe(role="Role for which all members should be displayed.")


### PR DESCRIPTION
When i pulled the repo and tried to run `python main.py` I got the following error:
```bash
Loaded cogs.username_fetcher
Loaded cogs.sync
Loaded cogs.info
Traceback (most recent call last):
  File "discord/ext/commands/bot.py", line 951, in _load_from_module_spec
    spec.loader.exec_module(lib)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 879, in exec_module
  File "<frozen importlib._bootstrap_external>", line 1017, in get_code
  File "<frozen importlib._bootstrap_external>", line 947, in source_to_code
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "TMW_Bot/cogs/gatekeeper.py", line 374
    description = "\n".join([f"{role.mention}: {len(role.members)} ({len(
                             ^
SyntaxError: unterminated string literal (detected at line 374)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/TMW_Bot/main.py", line 30, in <module>
    asyncio.run(main(cogs_to_load))
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "TMW_Bot/main.py", line 20, in main
    await my_bot.load_cogs(cogs_to_load)
  File "TMW_Bot/lib/bot.py", line 39, in load_cogs
    await self.load_extension(cog)
  File "discord/ext/commands/bot.py", line 1029, in load_extension
    await self._load_from_module_spec(spec, name)
  File "discord/ext/commands/bot.py", line 954, in _load_from_module_spec
    raise errors.ExtensionFailed(key, e) from e
discord.ext.commands.errors.ExtensionFailed: Extension 'cogs.gatekeeper' raised an error: SyntaxError: unterminated string literal (detected at line 374) (gatekeeper.py, line 374)
```

This happened without any changes from me. I implemented a chat solution so I could move on; be wary of this fix.