### PR TITLE
Feature improved stats graph

### DIFF
--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -84,16 +84,15 @@ def process_logs(logs):
     fig, ax = plt.subplots(figsize=(16, 12))
     plt.title('Points Over Time', fontweight='bold', fontsize=20)
     plt.ylabel('Points', fontweight='bold', fontsize=14)
-    plt.xlabel('Date', fontweight='bold', fontsize=14)
+    plt.xlabel('Date' + x_lab, fontweight='bold', fontsize=14)
 
-    accumulator = 0
-    for media_type in df_plot.columns:
-        col = df_plot[media_type]
-        ax.bar(df_plot.index, col, bottom=accumulator, color=color_dict.get(media_type, 'gray'), label=media_type)
-        accumulator += col
+    # Plot the data as a stacked bar chart
+    df_plot.plot(kind='bar', stacked=True, ax=ax, color=[color_dict.get(col, 'gray') for col in df_plot.columns])
 
-    ax.legend(df_plot.columns)
-    plt.xticks(df_plot.index, fontsize=10, rotation=45, horizontalalignment='right')
+    # Set custom x-axis labels based on the determined date format
+    ax.set_xticklabels(date_labels)
+    plt.xticks(rotation=45, ha='right')
+    plt.legend(loc='best')
     plt.grid()
 
     # Save the plot to a buffer

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -11,7 +11,8 @@ from lib.media_types import MEDIA_TYPES
 from lib.bot import TMWBot
 
 from .username_fetcher import get_username_db
-
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import pandas as pd
 import io

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -45,6 +45,31 @@ def process_logs(logs):
         log_dict[log[0]][log_date.date()] += log[2]
 
     df_plot = pd.DataFrame(log_dict).fillna(0)
+    df_plot.index = pd.to_datetime(df_plot.index)
+
+    full_date_range = pd.date_range(start=df_plot.index.min(), end=df_plot.index.max())
+    df_plot = df_plot.reindex(full_date_range, fill_value=0)
+
+    if len(df_plot) > 365 * 2:
+        df_plot = df_plot.resample('QE').sum()
+
+        def format_quarters(date):
+            quarter = (date.month - 1) // 3 + 1
+            return f"{date.year}-Q{quarter}"
+
+        x_lab = " (year-quarter)"
+        date_labels = df_plot.index.map(format_quarters)
+    elif len(df_plot) > 30 * 7:
+        df_plot = df_plot.resample('ME').sum()
+        x_lab = " (year-mounth)"
+        date_labels = df_plot.index.strftime("%Y-%m")
+    elif len(df_plot) > 30:
+        df_plot = df_plot.resample('W').sum()
+        x_lab = " (year-week)"
+        date_labels = df_plot.index.strftime("%Y-%W")
+    else:
+        date_labels = df_plot.index.strftime("%Y-%m-%d")
+        x_lab = ""
 
     color_dict = {
         "Book": "tab:orange",


### PR DESCRIPTION
This PR changes the number of bars displayed when a user request to see their immersion stats. There are 4 view modes are are determined by the number of days the user is requesting to see

1. Daily for < 30 days worth of logs
![daily](https://github.com/user-attachments/assets/fcef6c24-82e9-47a4-b741-54c0a8e085ec)
2. Week weekly for between 30 and 210 days days worth of logs
![weekly](https://github.com/user-attachments/assets/046799bc-72df-4949-bea2-143d65da49aa)
3. Montly between 211 and and 720 days
![monthly](https://github.com/user-attachments/assets/188a8662-07cf-4a9c-9886-a4bb4e1b0fbb)
4. quarerly for more than 2 years worth of logs
![quaterly](https://github.com/user-attachments/assets/85d2b1e0-7695-445f-ae62-d23fcc667a61)

The method ensures that there's never more than ~30 bars in a given graph, keeping it looking clean imo.
I tested the bot in my DMs on three users but I'm not sure how to do more robust testing on bots, sorry. 
