### PR TITLE
Feature media filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ cogs/testing_*
 .env
 .vscode
 data
+.flake8
+poetry.lock
+*.toml

--- a/cogs/immersion_log.py
+++ b/cogs/immersion_log.py
@@ -283,7 +283,7 @@ class ImmersionLog(commands.Cog):
             await logged_message.reply(f"> {comment}")
 
         if achievement_reached:
-            await logged_message.reply(f"🎉 **Achievement Reached!** 🎉\n\n**{current_achievement['title']}**\n\n{current_achievement["description"]}")
+            await logged_message.reply(f"🎉 **Achievement Reached!** 🎉\n\n**{current_achievement['title']}**\n\n{current_achievement['description']}")
 
     async def get_consecutive_days_logged(self, user_id: int) -> int:
         result = await self.bot.GET(GET_CONSECUTIVE_DAYS_QUERY, (user_id,))

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -17,12 +17,15 @@ from .username_fetcher import get_username_db
 import matplotlib
 matplotlib.use('Agg')
 
-GET_USER_LOGS_FOR_PERIOD_QUERY = """
+GET_USER_LOGS_FOR_PERIOD_QUERY_BASE = """
     SELECT media_type, amount_logged, points_received, log_date
     FROM logs
     WHERE user_id = ? AND log_date BETWEEN ? AND ?
     ORDER BY log_date;
 """
+
+GET_USER_LOGS_FOR_PERIOD_QUERY_WITH_MEDIA_TYPE = GET_USER_LOGS_FOR_PERIOD_QUERY_BASE + " AND media_type = ? ORDER BY log_date;"
+GET_USER_LOGS_FOR_PERIOD_QUERY_BASE += " ORDER BY log_date;"
 
 
 def process_logs(logs):

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -110,8 +110,24 @@ class ImmersionLogMe(commands.Cog):
         self.bot = bot
 
     @discord.app_commands.command(name='log_stats', description='Display an immersion overview for a specified period.')
-    @discord.app_commands.describe(user='Optional user to display the immersion overview for.', from_date='Optional start date (YYYY-MM-DD).', to_date='Optional end date (YYYY-MM-DD).')
-    async def log_stats(self, interaction: discord.Interaction, user: Optional[discord.User] = None, from_date: Optional[str] = None, to_date: Optional[str] = None):
+    @discord.app_commands.describe(
+        user='Optional user to display the immersion overview for.',
+        from_date='Optional start date (YYYY-MM-DD).',
+        to_date='Optional end date (YYYY-MM-DD).',
+        immersion_type='Optional type of immersion to filter by (e.g., reading, listening, etc.).'
+    )
+    @discord.app_commands.choices(
+        immersion_type=[
+            discord.app_commands.Choice(name="Listening Time", value="Listening Time"),
+            discord.app_commands.Choice(name="Visual Novel", value="Visual Novel"),
+            discord.app_commands.Choice(name="Reading Time", value="Reading Time"),
+            discord.app_commands.Choice(name="Anime", value="Anime"),
+            discord.app_commands.Choice(name="Manga", value="Manga"),
+            discord.app_commands.Choice(name="Book", value="Book"),
+            discord.app_commands.Choice(name="Reading", value="Reading"),
+        ]
+    )
+    async def log_stats(self, interaction: discord.Interaction, user: Optional[discord.User] = None, from_date: Optional[str] = None, to_date: Optional[str] = None, immersion_type: Optional[str] = None):
         if not await is_valid_channel(interaction):
             return await interaction.response.send_message("You can only use this command in DM or in the log channels.", ephemeral=True)
         await interaction.response.defer()

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -21,7 +21,6 @@ GET_USER_LOGS_FOR_PERIOD_QUERY_BASE = """
     SELECT media_type, amount_logged, points_received, log_date
     FROM logs
     WHERE user_id = ? AND log_date BETWEEN ? AND ?
-    ORDER BY log_date;
 """
 
 GET_USER_LOGS_FOR_PERIOD_QUERY_WITH_MEDIA_TYPE = GET_USER_LOGS_FOR_PERIOD_QUERY_BASE + " AND media_type = ? ORDER BY log_date;"

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -65,7 +65,7 @@ def process_logs(logs):
         df_plot = df_plot.resample('ME').sum()
         x_lab = " (year-mounth)"
         date_labels = df_plot.index.strftime("%Y-%m")
-    elif len(df_plot) > 30:
+    elif len(df_plot) > 31:
         df_plot = df_plot.resample('W').sum()
         x_lab = " (year-week)"
         date_labels = df_plot.index.strftime("%Y-%W")

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -9,7 +9,7 @@ from typing import Optional
 from datetime import datetime
 import asyncio
 
-from lib.media_types import MEDIA_TYPES
+from lib.media_types import MEDIA_TYPES, LOG_CHOICES
 from lib.bot import TMWBot
 from lib.immersion_helpers import is_valid_channel
 
@@ -124,17 +124,7 @@ class ImmersionLogMe(commands.Cog):
         to_date='Optional end date (YYYY-MM-DD).',
         immersion_type='Optional type of immersion to filter by (e.g., reading, listening, etc.).'
     )
-    @discord.app_commands.choices(
-        immersion_type=[
-            discord.app_commands.Choice(name="Listening Time", value="Listening Time"),
-            discord.app_commands.Choice(name="Visual Novel", value="Visual Novel"),
-            discord.app_commands.Choice(name="Reading Time", value="Reading Time"),
-            discord.app_commands.Choice(name="Anime", value="Anime"),
-            discord.app_commands.Choice(name="Manga", value="Manga"),
-            discord.app_commands.Choice(name="Book", value="Book"),
-            discord.app_commands.Choice(name="Reading", value="Reading"),
-        ]
-    )
+    @discord.app_commands.choices(immersion_type=LOG_CHOICES)
     async def log_stats(self, interaction: discord.Interaction, user: Optional[discord.User] = None, from_date: Optional[str] = None, to_date: Optional[str] = None, immersion_type: Optional[str] = None):
         if not await is_valid_channel(interaction):
             return await interaction.response.send_message("You can only use this command in DM or in the log channels.", ephemeral=True)

--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -6,8 +6,7 @@ from discord.ext import commands
 
 from typing import Optional
 
-from datetime import datetime, timedelta
-from collections import defaultdict
+from datetime import datetime
 import asyncio
 
 from lib.media_types import MEDIA_TYPES


### PR DESCRIPTION
The stats bot can now filter logs by immersion type
![image](https://github.com/user-attachments/assets/97b8ec0b-6d66-4444-a4db-897582780ca5)

If a user choses to filter by a media type, then the graph units are changed
![image](https://github.com/user-attachments/assets/8ec3b74f-2ea4-4f7b-8f29-0ab0667962a8)

This PR also adjusts the grouping range to ensure that when requesting logs at the end of the month, the days display method is still used. 

This PR should close #7 