### PR TITLE
Feature progress bar

### DIFF
--- a/cogs/immersion_goals.py
+++ b/cogs/immersion_goals.py
@@ -112,9 +112,9 @@ async def check_goal_status(bot: TMWBot, user_id: int, media_type: str):
         if (created_at_dt <= current_time <= end_date_dt) and progress < goal_value:
             goal_status = f"Goal in progress: `{progress}`/`{goal_value}` {unit_name} for `{media_type}`. {progress_bar} - Ends <t:{timestamp_end}:R>."
         elif progress >= goal_value:
-            goal_status = f"Congratulations! You've achieved your goal of `{goal_value}` {unit_name} for `{media_type}` between <t:{timestamp_created}:D> and <t:{timestamp_end}:D>."
+            goal_status = f"🎉 Congratulations! You've achieved your goal of `{goal_value}` {unit_name} for `{media_type}` between <t:{timestamp_created}:D> and <t:{timestamp_end}:D>."
         else:
-            goal_status = f"You have failed to achieve your goal of `{goal_value}` {unit_name} for `{media_type}` by <t:{timestamp_end}:R>."
+            goal_status = f"⚠️ Goal failed: `{progress}`/`{goal_value}` {unit_name} for `{media_type}` by <t:{timestamp_end}:R>. {progress_bar}"
 
         goal_statuses.append(goal_status)
 

--- a/cogs/immersion_goals.py
+++ b/cogs/immersion_goals.py
@@ -102,8 +102,15 @@ async def check_goal_status(bot: TMWBot, user_id: int, media_type: str):
         else:
             unit_name = 'points'
 
+        # Calculate progress percentage and generate emoji progress bar
+        percentage = min(int((progress / goal_value) * 100), 100)
+        bar_filled = "🟩" * (percentage // 10)  # each green square represents 10%
+        bar_empty = "⬜" * (10 - (percentage // 10))
+        progress_bar = f"{bar_filled}{bar_empty} ({percentage}%)"
+
+        # Create status message based on goal progress
         if (created_at_dt <= current_time <= end_date_dt) and progress < goal_value:
-            goal_status = f"Goal is in progress: `{progress}`/`{goal_value}` {unit_name} for `{media_type}`. End time <t:{timestamp_end}:R>."
+            goal_status = f"Goal in progress: `{progress}`/`{goal_value}` {unit_name} for `{media_type}`. {progress_bar} - Ends <t:{timestamp_end}:R>."
         elif progress >= goal_value:
             goal_status = f"Congratulations! You've achieved your goal of `{goal_value}` {unit_name} for `{media_type}` between <t:{timestamp_created}:D> and <t:{timestamp_end}:D>."
         else:


### PR DESCRIPTION
Add a progress bar to the check_goal_status function in the immersion_goals cog. This progress bar uses the 🟩 & ⬜ emoji's to display the users progress. 50% of a goal would be displayed as:
```python
🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩⬜⬜⬜⬜⬜⬜⬜⬜⬜⬜
```
This makes the progress bar about as wide as the embeded message. An example call of the check_goal_status could look something like
![image](https://github.com/user-attachments/assets/4f48b748-c4a5-4120-a7d0-49352bf60384)
