### PR TITLE
Add hour and minute format for backfill_date and log_set_goal

### DIFF
--- a/cogs/immersion_goals.py
+++ b/cogs/immersion_goals.py
@@ -25,6 +25,11 @@ CREATE_GOAL_QUERY = """
     VALUES (?, ?, ?, ?, ?, ?);
 """
 
+CREATE_GOAL_QUERY_DEFAULT = """
+    INSERT INTO user_goals (user_id, media_type, goal_type, goal_value, end_date)
+    VALUES (?, ?, ?, ?, ?);
+"""
+
 GET_USER_GOALS_QUERY = """
     SELECT goal_id, media_type, goal_type, goal_value, end_date
     FROM user_goals
@@ -166,8 +171,11 @@ class GoalsCog(commands.Cog):
                 return await interaction.response.send_message("Invalid input. Please use a date in YYYY-MM-DD or YYYY-MM-DD HH:MM format.", ephemeral=True)
         else:
             start_date_dt = None
-
-        await self.bot.RUN(CREATE_GOAL_QUERY, (interaction.user.id, media_type, goal_type, goal_value, end_date_dt.strftime('%Y-%m-%d %H:%M:%S'), start_date_dt.strftime('%Y-%m-%d %H:%M:%S')))
+        
+        if start_date_dt == None:
+            await self.bot.RUN(CREATE_GOAL_QUERY_DEFAULT, (interaction.user.id, media_type, goal_type, goal_value, end_date_dt.strftime('%Y-%m-%d %H:%M:%S')))
+        else:
+            await self.bot.RUN(CREATE_GOAL_QUERY, (interaction.user.id, media_type, goal_type, goal_value, end_date_dt.strftime('%Y-%m-%d %H:%M:%S'), start_date_dt.strftime('%Y-%m-%d %H:%M:%S')))
 
         unit_name = MEDIA_TYPES[media_type]['unit_name'] if goal_type == 'amount' else 'points'
         timestamp = int(end_date_dt.timestamp())


### PR DESCRIPTION
- backfill_date for /log can now use YYYY-MM-DD HH:MM format, as well as the original YYYY-MM-DD (defaults to 0:00 UTC)
- For /log_set_goal, there is now a new optional parameter called "start_date" which will set the created_at database column to that specific date/datetime - follows same rules as above