### PR TITLE
Stop pinging required role when failing quiz

### DIFF
--- a/cogs/gatekeeper.py
+++ b/cogs/gatekeeper.py
@@ -363,7 +363,7 @@ class LevelUp(commands.Cog):
         if success and quiz_data['require_role']:
             role_to_have = message.guild.get_role(quiz_data['require_role'])
             if role_to_have not in member.roles:
-                await message.channel.send(f"{member.mention} You need the {role_to_have.mention} role to take this quiz.")
+                await message.channel.send(f"{member.mention} You need the {role_to_have.name} role to take this quiz.")
                 return
 
         if success:

--- a/cogs/gatekeeper.py
+++ b/cogs/gatekeeper.py
@@ -363,7 +363,10 @@ class LevelUp(commands.Cog):
         if success and quiz_data['require_role']:
             role_to_have = message.guild.get_role(quiz_data['require_role'])
             if role_to_have not in member.roles:
-                await message.channel.send(f"{member.mention} You need the {role_to_have.name} role to take this quiz.")
+                await message.channel.send(
+                    f"{member.mention} You need the {role_to_have.mention} role to take this quiz.",
+                    allowed_mentions=discord.AllowedMentions(roles=False)
+                )
                 return
 
         if success:


### PR DESCRIPTION
Stop pinging all Eternal Idol when someone who isn't Eternal Idol fails Immortal Idol quiz.
Haven't tested yet but it should work.
