### PR TITLE
implement quizzes in individual threads

### DIFF
--- a/cogs/gatekeeper.py
+++ b/cogs/gatekeeper.py
@@ -521,7 +521,7 @@ class LevelUp(commands.Cog):
 
     async def quiz_autocomplete_create(self, interaction: discord.Interaction, current_input: str):
         guild_id = interaction.guild.id
-        rank_names = [quiz['name'] for quiz in gatekeeper_settings['rank_structure'][guild_id]]
+        rank_names = [quiz['name'] for quiz in gatekeeper_settings['rank_structure'][guild_id] if quiz['command']]
         possible_choices = [discord.app_commands.Choice(name=rank_name, value=rank_name) for rank_name in rank_names if current_input.lower() in rank_name.lower()]
         return possible_choices[:25]
     


### PR DESCRIPTION
Quiz workflow:
1. User uses /role_quiz in valid_levelup_channels and selects one quiz
2. Creates a thread, invites both Kotoba and the user, then gives out quiz command
3. User pastes the quiz command in the thread and quiz starts
4. Thread gets automatically deleted after 24 hours
5. Cooldown resets every Sunday 0:00 UTC