### PR TITLE
Fix log_stats heatmap crash on newer pandas.

### DIFF
--- a/cogs/immersion_stats.py
+++ b/cogs/immersion_stats.py
@@ -107,7 +107,8 @@ def process_bar_data(df: pd.DataFrame, from_date: datetime, to_date: datetime, i
 
 
 def process_heatmap_data(df: pd.DataFrame, from_date: datetime, to_date: datetime) -> dict:
-    df = df.resample("D").sum()
+    # Keep only numeric points data so reindex fill values do not touch string columns.
+    df = df[["points_received"]].resample("D").sum()
     full_date_range = pd.date_range(start=datetime(df.index.year.min(), 1, 1), end=datetime(df.index.year.max(), 12, 31))
     df = df.reindex(full_date_range, fill_value=0)
     df["day"] = df.index.weekday


### PR DESCRIPTION
/log_stats started failing for users with:
```
TypeError: Invalid value '0' for dtype 'str'
```
### Problem
The heatmap path in `cogs/immersion_stats.py` was doing:
- daily resample on the DataFrame, then
- `reindex(..., fill_value=0)`
Since our `requirements.py` is not frozen, pandas version updates to a newer version that we are incompatible with.
With newer pandas string-dtype behavior, applying numeric fill values to string-typed data is no longer tolerated in the same way, so this raised the dtype error during command execution.

### Relevant pandas docs:
- Pandas 3.0.0 release notes: https://pandas.pydata.org/docs/whatsnew/v3.0.0.html
- Pandas 3.0 string migration guide: https://pandas.pydata.org/docs/user_guide/migration-3-strings.html

### Fix
I updated `process_heatmap_data()` to keep only numeric points data before resample/reindex:
- from: `df = df.resample("D").sum()`
- to: `df = df[["points_received"]].resample("D").sum()`
This ensures `fill_value=0` is only applied to numeric data, preventing the string dtype crash while preserving the intended heatmap output.

### Verification Notes

I updated my library versions and confirmed I see the problem with `/log_stats`. After making the code change, I reverified and confirmed it works again:

<img width="597" height="866" alt="スクリーンショット 2026-02-20 034827" src="https://github.com/user-attachments/assets/fa1f29ca-3253-4f73-89b3-ba38bee59c88" />